### PR TITLE
EAM-953: support for Hivemeta data cache in cluster V2 API

### DIFF
--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,0 +1,8 @@
+{
+  "tests/test_account.py::TestAccountCreate::test_all": true, 
+  "tests/test_account.py::TestAccountCreate::test_default_previous_account_plan": true, 
+  "tests/test_cluster.py::TestClusterList::test_state_down": true, 
+  "tests/test_cluster.py::TestClusterList::test_state_pending": true, 
+  "tests/test_cluster.py::TestClusterList::test_state_terminating": true, 
+  "tests/test_cluster.py::TestClusterList::test_state_up": true
+}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,8 +1,0 @@
-{
-  "tests/test_account.py::TestAccountCreate::test_all": true, 
-  "tests/test_account.py::TestAccountCreate::test_default_previous_account_plan": true, 
-  "tests/test_cluster.py::TestClusterList::test_state_down": true, 
-  "tests/test_cluster.py::TestClusterList::test_state_pending": true, 
-  "tests/test_cluster.py::TestClusterList::test_state_terminating": true, 
-  "tests/test_cluster.py::TestClusterList::test_state_up": true
-}

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -1618,7 +1618,7 @@ class ClusterInfoV2(object):
 
     def set_hive_settings(self, flavour, enable_hive_metadata_cache):
         self.engine_config['hive_settings'] = {}
-        self.engine_config['hive_settings'] ['enable_hive_metadata_cache'] = enable_hive_metadata_cache
+        self.engine_config['hive_settings'] ['is_metadata_cache_enabled'] = enable_hive_metadata_cache
 
     def set_fairscheduler_settings(self, fairscheduler_config_xml=None, default_pool=None):
         self.engine_config['hadoop_settings']['fairscheduler_settings'] = {}

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -1583,6 +1583,7 @@ class ClusterInfoV2(object):
                             custom_hadoop_config =None,
                             use_qubole_placement_policy=None,
                             enable_rubix=None,
+                            enable_hive_metadata_cache=None,
                             node_bootstrap_timeout=None,
                             presto_version=None,
                             custom_presto_config=None,
@@ -1600,6 +1601,7 @@ class ClusterInfoV2(object):
         self.set_spark_settings(flavour, spark_version, custom_spark_config)
         self.set_airflow_settings(flavour, dbtap_id, fernet_key, overrides)
         self.set_streamx_settings(flavour, kafka_brokers, kafka_version)
+        self.set_hive_settings(flavour, enable_hive_metadata_cache)
 
     def set_hadoop_settings(self,
                             flavour,
@@ -1613,6 +1615,10 @@ class ClusterInfoV2(object):
         self.engine_config['hadoop_settings']['use_qubole_placement_policy'] = use_qubole_placement_policy
         self.engine_config['hadoop_settings']['enable_rubix'] = enable_rubix
         self.engine_config['hadoop_settings']['node_bootstrap_timeout'] = node_bootstrap_timeout
+
+    def set_hive_settings(self, flavour, enable_hive_metadata_cache):
+        self.engine_config['hive_settings'] = {}
+        self.engine_config['hive_settings'] ['enable_hive_metadata_cache'] = enable_hive_metadata_cache
 
     def set_fairscheduler_settings(self, fairscheduler_config_xml=None, default_pool=None):
         self.engine_config['hadoop_settings']['fairscheduler_settings'] = {}
@@ -1791,6 +1797,7 @@ class ClusterInfoV2(object):
                         custom_hadoop_config=None,
                         use_qubole_placement_policy=None,
                         enable_rubix=None,
+                        enable_hive_metadata_cache=None,
                         presto_version=None,
                         custom_presto_config=None,
                         spark_version=None,
@@ -1879,6 +1886,7 @@ class ClusterInfoV2(object):
                                 custom_hadoop_config,
                                 use_qubole_placement_policy,
                                 enable_rubix,
+                                enable_hive_metadata_cache,
                                 node_bootstrap_timeout,
                                 presto_version,
                                 custom_presto_config,

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -1619,7 +1619,7 @@ class ClusterInfoV2(object):
     def set_hive_settings(self, flavour, enable_hive_metadata_cache):
         if flavour and flavour == 'hadoop2':
             self.engine_config['hive_settings'] = {}
-            self.engine_config['hive_settings'] ['is_metadata_cache_enabled'] = enable_hive_metadata_cache
+            self.engine_config['hive_settings']['is_metadata_cache_enabled'] = enable_hive_metadata_cache
 
     def set_fairscheduler_settings(self, fairscheduler_config_xml=None, default_pool=None):
         self.engine_config['hadoop_settings']['fairscheduler_settings'] = {}

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -1601,7 +1601,7 @@ class ClusterInfoV2(object):
         self.set_spark_settings(flavour, spark_version, custom_spark_config)
         self.set_airflow_settings(flavour, dbtap_id, fernet_key, overrides)
         self.set_streamx_settings(flavour, kafka_brokers, kafka_version)
-        self.set_hive_settings(enable_hive_metadata_cache)
+        self.set_hive_settings(flavour, enable_hive_metadata_cache)
 
     def set_hadoop_settings(self,
                             flavour,
@@ -1616,9 +1616,10 @@ class ClusterInfoV2(object):
         self.engine_config['hadoop_settings']['enable_rubix'] = enable_rubix
         self.engine_config['hadoop_settings']['node_bootstrap_timeout'] = node_bootstrap_timeout
 
-    def set_hive_settings(self, enable_hive_metadata_cache):
-        self.engine_config['hive_settings'] = {}
-        self.engine_config['hive_settings'] ['is_metadata_cache_enabled'] = enable_hive_metadata_cache
+    def set_hive_settings(self, flavour, enable_hive_metadata_cache):
+        if flavour and flavour == 'hadoop2':
+            self.engine_config['hive_settings'] = {}
+            self.engine_config['hive_settings'] ['is_metadata_cache_enabled'] = enable_hive_metadata_cache
 
     def set_fairscheduler_settings(self, fairscheduler_config_xml=None, default_pool=None):
         self.engine_config['hadoop_settings']['fairscheduler_settings'] = {}

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -1601,7 +1601,7 @@ class ClusterInfoV2(object):
         self.set_spark_settings(flavour, spark_version, custom_spark_config)
         self.set_airflow_settings(flavour, dbtap_id, fernet_key, overrides)
         self.set_streamx_settings(flavour, kafka_brokers, kafka_version)
-        self.set_hive_settings(flavour, enable_hive_metadata_cache)
+        self.set_hive_settings(enable_hive_metadata_cache)
 
     def set_hadoop_settings(self,
                             flavour,
@@ -1616,7 +1616,7 @@ class ClusterInfoV2(object):
         self.engine_config['hadoop_settings']['enable_rubix'] = enable_rubix
         self.engine_config['hadoop_settings']['node_bootstrap_timeout'] = node_bootstrap_timeout
 
-    def set_hive_settings(self, flavour, enable_hive_metadata_cache):
+    def set_hive_settings(self, enable_hive_metadata_cache):
         self.engine_config['hive_settings'] = {}
         self.engine_config['hive_settings'] ['is_metadata_cache_enabled'] = enable_hive_metadata_cache
 


### PR DESCRIPTION
This is needed for writing py.test for QDS edition.